### PR TITLE
React to external changes to the userData directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Documentation
 
 
 * [storage](#module_storage)
-    * [.DEFAULT_DATA_PATH](#module_storage.DEFAULT_DATA_PATH) : <code>String</code>
+    * [.getDefaultDataPath()](#module_storage.getDefaultDataPath) ⇒ <code>String</code>
     * [.setDataPath(directory)](#module_storage.setDataPath)
     * [.getDataPath()](#module_storage.getDataPath) ⇒ <code>String</code>
     * [.get(key, [options], callback)](#module_storage.get)
@@ -44,15 +44,21 @@ Documentation
     * [.remove(key, [options], callback)](#module_storage.remove)
     * [.clear([options], callback)](#module_storage.clear)
 
-<a name="module_storage.DEFAULT_DATA_PATH"></a>
+<a name="module_storage.getDefaultDataPath"></a>
 
-### storage.DEFAULT_DATA_PATH : <code>String</code>
-**Kind**: static constant of <code>[storage](#module_storage)</code>  
-**Summary**: The default data path  
+### storage.getDefaultDataPath() ⇒ <code>String</code>
+**Kind**: static method of <code>[storage](#module_storage)</code>  
+**Summary**: Get the default data path  
+**Returns**: <code>String</code> - default data path  
+**Access:** public  
+**Example**  
+```js
+const defaultDataPath = storage.getDefaultDataPath()
+```
 <a name="module_storage.setDataPath"></a>
 
 ### storage.setDataPath(directory)
-The default data path is stored in `storage.DEFAULT_DATA_PATH`.
+The default value will be used if the directory is undefined.
 
 **Kind**: static method of <code>[storage](#module_storage)</code>  
 **Summary**: Set current data path  
@@ -60,7 +66,7 @@ The default data path is stored in `storage.DEFAULT_DATA_PATH`.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| directory | <code>String</code> | directory |
+| directory | <code>String</code> &#124; <code>Undefined</code> | directory |
 
 **Example**  
 ```js

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -39,11 +39,16 @@ const utils = require('./utils');
 const lock = new RWlock();
 
 /**
- * @summary The default data path
- * @type {String}
- * @constant
+ * @summary Get the default data path
+ * @function
+ * @public
+ *
+ * @returns {String} default data path
+ *
+ * @example
+ * const defaultDataPath = storage.getDefaultDataPath()
  */
-exports.DEFAULT_DATA_PATH = utils.DEFAULT_DATA_PATH;
+exports.getDefaultDataPath = utils.getDefaultDataPath;
 
 /**
  * @summary Set current data path
@@ -51,9 +56,9 @@ exports.DEFAULT_DATA_PATH = utils.DEFAULT_DATA_PATH;
  * @public
  *
  * @description
- * The default data path is stored in `storage.DEFAULT_DATA_PATH`.
+ * The default value will be used if the directory is undefined.
  *
- * @param {String} directory - directory
+ * @param {(String|Undefined)} directory - directory
  *
  * @example
  * const os = require('os');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,17 +30,24 @@ const electron = require('electron');
 const app = electron.app || electron.remote.app;
 
 /**
- * @summary The default data path
- * @type {String}
- * @constant
+ * @summary Get the default data path
+ * @function
+ * @public
+ *
+ * @returns {String} default data path
+ *
+ * @example
+ * const defaultDataPath = utils.getDefaultDataPath()
  */
-exports.DEFAULT_DATA_PATH = path.join(app.getPath('userData'), 'storage');
+exports.getDefaultDataPath = () => {
+  return path.join(app.getPath('userData'), 'storage');
+};
 
 /**
  * @summary The current data path
  * @type {String}
  */
-let currentDataPath = exports.DEFAULT_DATA_PATH;
+let currentDataPath;
 
 /**
  * @summary Set default data path
@@ -55,7 +62,8 @@ let currentDataPath = exports.DEFAULT_DATA_PATH;
  */
 exports.setDataPath = function(directory) {
   if (_.isNil(directory)) {
-    throw new Error(`Invalid data path: ${directory}`);
+    currentDataPath = undefined;
+    return;
   }
 
   if (!path.isAbsolute(directory)) {
@@ -77,7 +85,7 @@ exports.setDataPath = function(directory) {
  * console.log(dataPath);
  */
 exports.getDataPath = function() {
-  return currentDataPath;
+  return currentDataPath || exports.getDefaultDataPath();
 };
 
 /**

--- a/tests/storage.spec.js
+++ b/tests/storage.spec.js
@@ -44,7 +44,7 @@ describe('Electron JSON Storage', function() {
 
   // Ensure each test case is always ran in a clean state
   beforeEach(function(done) {
-    storage.setDataPath(utils.DEFAULT_DATA_PATH);
+    storage.setDataPath(utils.getDefaultDataPath());
     storage.clear(done);
   });
 
@@ -83,14 +83,14 @@ describe('Electron JSON Storage', function() {
 
   });
 
-  describe('.DEFAULT_DATA_PATH', function() {
+  describe('.getDefaultDataPath()', function() {
 
     it('should be a string', function() {
-      m.chai.expect(_.isString(storage.DEFAULT_DATA_PATH)).to.be.true;
+      m.chai.expect(_.isString(storage.getDefaultDataPath())).to.be.true;
     });
 
     it('should be an absolute path', function() {
-      m.chai.expect(path.isAbsolute(storage.DEFAULT_DATA_PATH)).to.be.true;
+      m.chai.expect(path.isAbsolute(storage.getDefaultDataPath())).to.be.true;
     });
 
   });
@@ -104,10 +104,10 @@ describe('Electron JSON Storage', function() {
       m.chai.expect(dataPath).to.equal(newDataPath);
     });
 
-    it('should throw given no path', function() {
-      m.chai.expect(function() {
-        storage.setDataPath();
-      }).to.throw('Invalid data path: undefined');
+    it('should set the default path if no argument', function() {
+      storage.setDataPath();
+      const dataPath = app.getPath('userData');
+      m.chai.expect(storage.getDataPath().indexOf(dataPath)).to.equal(0);
     });
 
     it('should throw given a relative path', function() {
@@ -122,7 +122,7 @@ describe('Electron JSON Storage', function() {
 
     it('should initially return the default data path', function() {
       const dataPath = storage.getDataPath();
-      m.chai.expect(dataPath).to.equal(utils.DEFAULT_DATA_PATH);
+      m.chai.expect(dataPath).to.equal(utils.getDefaultDataPath());
     });
 
     it('should be able to return new data paths', function() {
@@ -198,7 +198,7 @@ describe('Electron JSON Storage', function() {
             storage.set('foo', { location: 'new' }, callback);
           },
           function(callback) {
-            storage.setDataPath(utils.DEFAULT_DATA_PATH);
+            storage.setDataPath(utils.getDefaultDataPath());
             callback();
           },
           function(callback) {
@@ -560,7 +560,7 @@ describe('Electron JSON Storage', function() {
             storage.set('bar', { name: 'bar' }, callback);
           },
           function(callback) {
-            storage.setDataPath(utils.DEFAULT_DATA_PATH);
+            storage.setDataPath(utils.getDefaultDataPath());
             callback();
           },
           function(callback) {
@@ -583,7 +583,7 @@ describe('Electron JSON Storage', function() {
             callback();
           },
           function(callback) {
-            storage.setDataPath(utils.DEFAULT_DATA_PATH);
+            storage.setDataPath(utils.getDefaultDataPath());
             callback();
           },
           storage.getAll,

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -41,25 +41,35 @@ describe('Utils', function() {
       m.chai.expect(path.isAbsolute(utils.getDataPath())).to.be.true;
     });
 
-     it('should equal the dirname of the path returned by getFileName()', function() {
-       const fileName = utils.getFileName('foo');
-       const userDataPath = utils.getDataPath();
-       m.chai.expect(path.dirname(fileName)).to.equal(userDataPath);
-     });
+    it('should equal the dirname of the path returned by getFileName()', function() {
+      const fileName = utils.getFileName('foo');
+      const userDataPath = utils.getDataPath();
+      m.chai.expect(path.dirname(fileName)).to.equal(userDataPath);
+    });
+
+    it('should pick up external changes to the userData path', function() {
+      utils.setDataPath(undefined);
+      const oldDataPath = app.getPath('userData');
+      m.chai.expect(utils.getDataPath().indexOf(oldDataPath)).to.equal(0);
+      const newPath = os.platform() === 'win32' ? 'C:\\foo' : '/foo';
+      app.setPath('userData', newPath);
+      m.chai.expect(utils.getDataPath().indexOf(newPath)).to.equal(0);
+      app.setPath('userData', oldDataPath);
+    });
 
   });
 
   describe('.setDataPath()', function() {
 
     beforeEach(function() {
-      utils.setDataPath(utils.DEFAULT_DATA_PATH);
+      utils.setDataPath(utils.getDefaultDataPath());
     });
 
     it('should be able to go back to the default', function() {
       utils.setDataPath(path.join(os.tmpdir(), 'foo'));
-      m.chai.expect(utils.getDataPath()).to.not.equal(utils.DEFAULT_DATA_PATH);
-      utils.setDataPath(utils.DEFAULT_DATA_PATH);
-      m.chai.expect(utils.getDataPath()).to.equal(utils.DEFAULT_DATA_PATH);
+      m.chai.expect(utils.getDataPath()).to.not.equal(utils.getDefaultDataPath());
+      utils.setDataPath(utils.getDefaultDataPath());
+      m.chai.expect(utils.getDataPath()).to.equal(utils.getDefaultDataPath());
     });
 
     it('should change the user data path', function() {


### PR DESCRIPTION
The module should start storing files in the correct location if the
electron userData directory in externally changed. i.e:

```
electron.app.setPath('userData', '/foo');
```

Fixes: https://github.com/electron-userland/electron-json-storage/issues/86
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>