### PR TITLE
Remove ES6 features to work with webpack / create-react-app

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -332,7 +332,7 @@ exports.has = function(key, options, callback) {
       dataPath: options.dataPath
     })),
     function(filename, done) {
-      fs.stat(filename, (error) => {
+      fs.stat(filename, function(error) {
         if (error) {
           if (error.code === 'ENOENT') {
             return done(null, false);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,7 +39,7 @@ const app = electron.app || electron.remote.app;
  * @example
  * const defaultDataPath = utils.getDefaultDataPath()
  */
-exports.getDefaultDataPath = () => {
+exports.getDefaultDataPath = function() {
   return path.join(app.getPath('userData'), 'storage');
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -47,7 +47,7 @@ exports.getDefaultDataPath = function() {
  * @summary The current data path
  * @type {String}
  */
-let currentDataPath;
+var currentDataPath;
 
 /**
  * @summary Set default data path


### PR DESCRIPTION
I'm trying to use this module in conjunction with `create-react-app` / `react-scripts`, but I'm running into an issue when building via `yarn dist`.

> ➜  yarn dist
> yarn run v1.5.1
> $ yarn run build && electron-builder
> $ react-app-rewired build
> Creating an optimized production build...
> Failed to compile.
> 
> Failed to minify the code from this file: 
> 
>  	./node_modules/electron-json-storage/lib/storage.js:335 
> 
> Read more here: http://bit.ly/2tRViJ9
> 
> error An unexpected error occurred: "Command failed.
> Exit code: 1
> Command: sh
> Arguments: -c react-app-rewired build
> Directory: /Users/mhuggins/Development/nos/client
> Output:
> ".
> info If you think this is a bug, please open a bug report with the information provided in "/Users/mhuggins/Development/nos/client/yarn-error.log".
> info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
> error An unexpected error occurred: "Command failed.
> Exit code: 1
> Command: sh
> Arguments: -c yarn run build && electron-builder
> Directory: /Users/mhuggins/Development/nos/client
> Output:
> ".
> info If you think this is a bug, please open a bug report with the information provided in "/Users/mhuggins/Development/nos/client/yarn-error.log".
> info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

If you take a look at the link in that error (http://bit.ly/2tRViJ9), the issue is that this package uses ES6 features as part of the file it exports, which is not compatible in such an environment.  The solution is either to use ES6 and transpile it, or just not use ES6 in the files your package exports.  This package is very close to not using ES6, so I made 3 minor changes that make it compatible with webpack apps like mine.