### PR TITLE
Only list JSON files in .keys()

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -432,7 +432,7 @@ exports.keys = function(options, callback) {
     fs.readdir,
     function(keys, callback) {
       callback(null, _.map(_.reject(keys, function(key) {
-        return _.includes([ '.DS_Store' ], key);
+        return path.extname(key) !== '.json';
       }), function(key) {
         return path.basename(decodeURIComponent(key), '.json');
       }));

--- a/tests/storage.spec.js
+++ b/tests/storage.spec.js
@@ -972,14 +972,16 @@ describe('Electron JSON Storage', function() {
 
     });
 
-    describe('given a .DS_Store file in the settings directory', function() {
+    describe('given invalid files in the settings directory', function() {
 
       beforeEach(function(done) {
         async.waterfall([
           _.partial(storage.set, 'one', 'foo'),
           _.partial(storage.set, 'two', 'bar'),
           _.partial(storage.set, 'three', 'baz'),
-          _.partial(fs.writeFile, path.join(storage.getDataPath(), '.DS_Store'), 'foo')
+          _.partial(fs.writeFile, path.join(storage.getDataPath(), '.DS_Store'), 'foo'),
+          _.partial(fs.writeFile, path.join(storage.getDataPath(), 'one.json.lock.STALE'), 'foo'),
+          _.partial(fs.writeFile, path.join(storage.getDataPath(), 'one.json.lock'), 'foo')
         ], done);
       });
 


### PR DESCRIPTION
Fixes: https://github.com/electron-userland/electron-json-storage/issues/132